### PR TITLE
[DEVOPS] Fixing Win/Mac issues

### DIFF
--- a/back/.gitattributes
+++ b/back/.gitattributes
@@ -1,0 +1,17 @@
+* text=auto eol=lf
+
+*.conf text eol=lf
+*.html text eol=lf
+*.ini text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.php text eol=lf
+*.sh text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+bin/console text eol=lf
+composer.lock text eol=lf merge=ours
+
+*.ico binary
+*.png binary

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app/backend
 RUN apt update
 
 RUN apt-get update && apt-get install -y \
+    dos2unix \
     gnupg \
     g++ \
     procps \
@@ -50,6 +51,7 @@ ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
 COPY --from=composer_upstream --link /usr/bin/composer /usr/bin/composer
 COPY --link --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN dos2unix /usr/local/bin/docker-entrypoint
 
 ENTRYPOINT ["docker-entrypoint"]
 

--- a/back/Makefile
+++ b/back/Makefile
@@ -72,13 +72,16 @@ db.hash-password:
 # Development #
 ###############
 
+serve.reset:
+	symfony server:stop && echo "Symfony server stopped" || echo "Symfony server not running"
+
 ## Dev - Start the whole application for development purposes
 serve:
 	# https://www.npmjs.com/package/concurrently
 	npx concurrently "make serve.docker" "make serve.php" --names="Docker,Symfony" --prefix=name --kill-others --kill-others-on-fail
 
 ## Dev - Start Symfony web server
-serve.php:
+serve.php: serve.reset
 	symfony server:start --port=63280
 
 ## Dev - Start Docker services
@@ -96,7 +99,7 @@ serve@test:
 
 serve.php@test: export APP_ENV = test
 serve.php@test: export APP_DEBUG = 1
-serve.php@test:
+serve.php@test: serve.reset
 	symfony server:start --port=63290
 
 ## Stop Symfony web server

--- a/back/docker-entrypoint.sh
+++ b/back/docker-entrypoint.sh
@@ -33,9 +33,10 @@ if grep -q ^DATABASE_URL= .env; then
 fi
 
 mkdir -p var
-setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
-setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+chmod -R u+rwX var
+chown -R www-data:$(whoami) var
 
 make db.install
-
+make install.jwt
+ps ax | grep 'php-fpm: master' | awk -F ' ' '{print $1}' | xargs kill -9 2>/dev/null || true
 exec docker-php-entrypoint "$@"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,7 +9,7 @@ services:
 
 ###> symfony/mailer ###
   mailer:
-    profiles: ['', docker, local]
+    profiles: ['', docker, local, backend]
     image: schickling/mailcatcher
     ports: ["1025", "62551:1080"]
 ###< symfony/mailer ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,17 +3,17 @@ version: "3"
 services:
   react:
       profiles: ['', docker]
-      command: "npm run dev"
       build:
           context: ./front
           dockerfile: Dockerfile
       working_dir: /app/frontend
       volumes:
           - ./front:/app/frontend
+          - /app/frontend/node_modules
       ports:
           - 63281:63281
   symfony:
-      profiles: ['', docker]
+      profiles: ['', docker, backend]
       command: "make serve.php"
       environment:
             DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-password}@database:5432/${POSTGRES_DB:-app}
@@ -27,7 +27,7 @@ services:
           - 63280:63280
           - 63290:63290
   database:
-    profiles: ['', local, docker]
+    profiles: ['', local, docker, backend]
     image: postgres:${POSTGRES_VERSION:-15}-alpine
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-app}

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -9,3 +9,5 @@ RUN npm install
 COPY --link . ./
 
 EXPOSE 63281
+
+CMD ["npm", "run", "dev"]


### PR DESCRIPTION
# How-to

For applying this patch, everyone that ran previous versions of the deployment must delete their local containers/images to regenerate it.

```bash
docker rmi {IMAGES_NAMES} -f
```

# Changes

- added `backend` docker compose profile (Symfony, Postgresql, Mailer)
- fixed various issues from Mac and Windows

# Notes

There's still an existing issue with Windows as the project use unusual ports that may collide sometimes with [Windows dynamic reserved ports](https://en.wikipedia.org/wiki/Ephemeral_port). Possible workaround is to move the port we use into a lower segment or patch all developer's Win OS to not use a specific range. ([explanation](https://medium.com/@sevenall/completely-solve-the-problem-of-docker-containers-not-starting-or-running-on-windows-10-due-to-port-57f16ed6143))