### PR TITLE
[FRONT] feature: Add cache for Apiary list & store for creation mutation

### DIFF
--- a/front/src/api/apollo/typePolicies.ts
+++ b/front/src/api/apollo/typePolicies.ts
@@ -2,10 +2,14 @@ import { TypePolicies } from '@apollo/client';
 
 export enum Types {
   User = 'User',
+  Apiary = 'Apiary',
 }
 
 export default {
   [Types.User]: {
+    keyFields: ['uid'],
+  },
+  [Types.Apiary]: {
     keyFields: ['uid'],
   },
   Query: {
@@ -16,6 +20,14 @@ export default {
           me: {
             merge: (existing: object, incoming: object) => ({ ...existing, ...incoming }),
           },
+          list: {
+            merge: (incoming: object) => incoming,
+          },
+        },
+      },
+      Apiary: {
+        merge: (existing, incoming) => ({ ...existing, ...incoming }),
+        fields: {
           list: {
             merge: (incoming: object) => incoming,
           },

--- a/front/src/api/graphql/store/apiaries.ts
+++ b/front/src/api/graphql/store/apiaries.ts
@@ -1,0 +1,44 @@
+import { ApolloCache } from '@apollo/client';
+import ListApiariesQuery from '@graphql/query/apiary/ListApiaries.graphql';
+
+interface ApiaryRef {
+  uid: string
+}
+
+interface Store {
+  Apiary: {
+    list: ApiaryRef[]
+  }
+}
+
+/**
+ * Update Apollo store on new service created.
+ * Should make the new item visible on the listing.
+ *
+ * @see https://www.apollographql.com/docs/react/caching/cache-interaction/#using-graphql-queries
+ */
+export function onCreateApiary(
+  store: ApolloCache<unknown>,
+  apiary: ApiaryRef,
+) {
+  const query = ListApiariesQuery;
+  // Attempt to read the data from the cache:
+  const previousData = store.readQuery<Store>({ query });
+
+  if (!previousData) {
+    // If no data was fetched yet, we don't need to do anything
+    return;
+  }
+
+  const data = {
+    ...previousData,
+    Apiary: {
+      ...previousData.Apiary,
+      // Append the newly created service to the list:
+      list: [...previousData.Apiary.list, apiary],
+    },
+  };
+
+  // Write the data back to the cache:
+  store.writeQuery({ query, data });
+}


### PR DESCRIPTION
Depends on #25 

Add apollo cache for Apiary : 

1- Merge at list query
2- Store at mutation creation 
![Capture d’écran 2024-01-30 à 11 32 07](https://github.com/Hive-Five-project/hive-five/assets/113915173/4b29192a-317f-429e-9a6d-334864ab37f7)
![Capture d’écran 2024-01-30 à 11 31 07](https://github.com/Hive-Five-project/hive-five/assets/113915173/e77aba35-f3d0-4450-8140-e6dbe2b77f30)

💡 Install this extension : https://chromewebstore.google.com/detail/apollo-client-devtools/jdkknkkbebbapilgoeccciglkfbmbnfm
Reaaally cool for graphql cache