### PR TITLE
[CI] enforcing PR names

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -7,11 +7,38 @@ on:
       - synchronize
       - edited
 jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check title
+        id: check-title
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_ID="${{ github.event.pull_request.number }}"
+          REGEX="^\[(FRONT|BACK|DEVOPS|TEST|DOCS|FIX|REFACTOR|STYLE|CHORE|CI|BUILD|PERF|REVERT|WIP)\/{0,1}[A-Z]*\] [a-zA-Z0-9+,;&\/ ]+$"
+          if [[ ! $PR_TITLE =~ $REGEX ]]; then
+            echo "Pull request title is not prefixed with one of the following verbs: FRONT, BACK, DEVOPS, TEST, DOCS, FIX, REFACTOR, STYLE, CHORE, CI, BUILD, PERF, REVERT, WIP"
+            echo " "
+            echo "If you want to merge this pull request, please update the title to match the following format:"
+            echo " "
+            echo "  [<VERB>] <description>"
+            echo " or "
+            echo "  [<VERB>/<SUBJECT>] <description>"
+            echo " "
+            echo "Example:"
+            echo " "
+            echo "  [FRONT] Add new button"
+            exit 1
+          fi
   check-branches:
     runs-on: ubuntu-latest
     steps:
       - name: Check branches
         run: |
+          if [ ${{ github.head_ref }} == "main" ]; then
+            echo "Pull requests from main branch are not allowed."
+            exit 1
+          fi
           if [ ${{ github.head_ref }} != "staging" ] && [ ${{ github.base_ref }} == "main" ]; then
             echo "Merge requests to main branch are only allowed from staging branch."
             exit 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,16 +1,15 @@
 name: Deploy
 on:
-    workflow_run:
-        workflows: ["Tests"]
-        branches: [main, staging]
-        types: 
-            - completed
+    push:
+        branches:
+            - main
+            - staging
 
 env:
     REMOTE_HOST: "95.111.228.177"
     REMOTE_USER: "hivefive"
-    PATH_STAGING: "/var/www/hivefive"
-    PATH_PRODUCTION: "/var/www/hivefive_staging"
+    PATH_PRODUCTION: "/var/www/hivefive"
+    PATH_STAGING: "/var/www/hivefive_staging"
     URL_STAGING: "https://staging.hivefive.online"
     URL_PRODUCTION: "https://hivefive.online"
 
@@ -20,7 +19,6 @@ jobs:
         environment:
           name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
           url: ${{ github.ref == 'refs/heads/main' && env.URL_PRODUCTION || env.URL_STAGING }}
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
@@ -48,7 +46,6 @@ jobs:
                     rsync -avz -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" dist/* ${{ env.REMOTE_USER }}@${{ env.REMOTE_HOST }}:${{ github.ref == 'refs/heads/main' && env.PATH_PRODUCTION || env.PATH_STAGING }}/client
     backend:
         name: Deploy Backend
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
## Summary

Currently, PRs are not entirely managed by their respective devs due to the repo being still under heavy changes in it's workflow. With the needs of **developer to be fully autonomous** on the management of their PR, few guidelines needs to be respected to have a constant flow of operation and namings. 

This PR will now **force** a specific pattern for titles to follow: (docs is being written in #24 for a further release)

- **[\<VERB>] \<description>**

or

- **[\<VERB>/\<SUBJECT>] \<description>**
__SUBJECT__ can be anything as long as it stays in FULL CAPS and contain only alpha chars.

with **\<VERB>** being for now:

- FRONT
- BACK
- DEVOPS
- TEST
- DOCS
- FIX
- REFACTOR
- STYLECHORE
- CI
- BUILD
- PERF
- REVERT
- WIP

### Added

- (71da932) enforcing paths name to follow a pattern

### Fixes

- (facb0c0) deploy path were mixed leading in a switch between prod/staging URL