### PR TITLE
[FRONT] Fix list of apiaries cache on create apiary

### DIFF
--- a/front/src/api/apollo/typePolicies.ts
+++ b/front/src/api/apollo/typePolicies.ts
@@ -28,7 +28,7 @@ export default {
       Apiary: {
         merge: (existing, incoming) => ({ ...existing, ...incoming }),
         fields: {
-          list: {
+          listMyApiaries: {
             merge: (incoming: object) => incoming,
           },
         },

--- a/front/src/api/graphql/store/apiaries.ts
+++ b/front/src/api/graphql/store/apiaries.ts
@@ -35,7 +35,7 @@ export function onCreateApiary(
     Apiary: {
       ...previousData.Apiary,
       // Append the newly created service to the list:
-      list: [...previousData.Apiary.listMyApiaries, apiary],
+      listMyApiaries: [...previousData.Apiary.listMyApiaries, apiary],
     },
   };
 


### PR DESCRIPTION
To test: Create an apiary => Go back to the list of apiaries to see your newly created apiary