### PR TITLE
[FRONT] Fix header bounce on bottom page during scroll

### DIFF
--- a/front/src/layouts/AppLayout.tsx
+++ b/front/src/layouts/AppLayout.tsx
@@ -11,12 +11,13 @@ export default function AppLayout({ children }: PropsWithChildren) {
       header={{
         height: 61,
         collapsed: !pinned,
+        offset: false,
       }}
       padding="md"
     >
       <Header />
 
-      <AppShell.Main>
+      <AppShell.Main style={{ paddingTop: 61 }}>
         {children}
       </AppShell.Main>
 


### PR DESCRIPTION
Fix that:

https://github.com/Hive-Five-project/hive-five/assets/55053185/595040fb-bc30-4d0f-96c6-ecf05d070f7e

