### PR TITLE
[FRONT] Fix beehive cache navigate

### DIFF
--- a/front/src/api/apollo/typePolicies.ts
+++ b/front/src/api/apollo/typePolicies.ts
@@ -3,6 +3,7 @@ import { TypePolicies } from '@apollo/client';
 export enum Types {
   User = 'User',
   Apiary = 'Apiary',
+  Beehive = 'Beehive',
 }
 
 export default {
@@ -10,6 +11,9 @@ export default {
     keyFields: ['uid'],
   },
   [Types.Apiary]: {
+    keyFields: ['uid'],
+  },
+  [Types.Beehive]: {
     keyFields: ['uid'],
   },
   Query: {
@@ -29,6 +33,14 @@ export default {
         merge: (existing, incoming) => ({ ...existing, ...incoming }),
         fields: {
           listMyApiaries: {
+            merge: (incoming: object) => incoming,
+          },
+        },
+      },
+      Beehive: {
+        merge: (existing, incoming) => ({ ...existing, ...incoming }),
+        fields: {
+          listBeehivesFromApiary: {
             merge: (incoming: object) => incoming,
           },
         },

--- a/front/src/api/graphql/mutation/apiary/CreateApiary.graphql
+++ b/front/src/api/graphql/mutation/apiary/CreateApiary.graphql
@@ -1,4 +1,4 @@
-mutation($payload: ApiaryPayload!) {
+mutation createApiary ($payload: ApiaryPayload!) {
   Apiary {
     create(payload: $payload) {
       uid

--- a/front/src/api/graphql/mutation/apiary/UpdateApiary.graphql
+++ b/front/src/api/graphql/mutation/apiary/UpdateApiary.graphql
@@ -1,4 +1,4 @@
-mutation($uid: ULID!, $payload: ApiaryPayload!) {
+mutation updateApiary ($uid: ULID!, $payload: ApiaryPayload!) {
   Apiary {
     update(uid: $uid ,payload: $payload) {
       uid

--- a/front/src/api/graphql/mutation/beehive/CreateBeehive.graphql
+++ b/front/src/api/graphql/mutation/beehive/CreateBeehive.graphql
@@ -1,4 +1,4 @@
-mutation($payload: BeehivePayload!) {
+mutation createBeehive ($payload: BeehivePayload!) {
   Beehive {
     create(payload: $payload) {
       uid

--- a/front/src/api/graphql/mutation/beehive/FindBeehive.graphql
+++ b/front/src/api/graphql/mutation/beehive/FindBeehive.graphql
@@ -1,4 +1,4 @@
-query($uid: ULID!) {
+query findBeehive ($uid: ULID!) {
   Beehive {
     find(uid: $uid) {
       uid

--- a/front/src/api/graphql/mutation/beehive/UpdateBeehive.graphql
+++ b/front/src/api/graphql/mutation/beehive/UpdateBeehive.graphql
@@ -1,4 +1,4 @@
-mutation($uid: ULID!, $payload: BeehivePayload!) {
+mutation updateBeehive ($uid: ULID!, $payload: BeehivePayload!) {
   Beehive {
     update(uid: $uid, payload: $payload) {
       uid

--- a/front/src/api/graphql/mutation/user/CreateUser.graphql
+++ b/front/src/api/graphql/mutation/user/CreateUser.graphql
@@ -1,4 +1,4 @@
-mutation($payload: UserPayload!) {
+mutation createUser ($payload: UserPayload!) {
   User {
     create(payload: $payload) {
       uid

--- a/front/src/api/graphql/mutation/user/DeleteUser.graphql
+++ b/front/src/api/graphql/mutation/user/DeleteUser.graphql
@@ -1,4 +1,4 @@
-mutation($uid: ULID!) {
+mutation deleteUser ($uid: ULID!) {
   User {
     delete(uid: $uid)
   }

--- a/front/src/api/graphql/mutation/user/ForgotPassword.graphql
+++ b/front/src/api/graphql/mutation/user/ForgotPassword.graphql
@@ -1,4 +1,4 @@
-mutation($email: Email!) {
+mutation forgotPassword ($email: Email!) {
   User {
     forgotPassword(email: $email)
   }

--- a/front/src/api/graphql/mutation/user/ResetPassword.graphql
+++ b/front/src/api/graphql/mutation/user/ResetPassword.graphql
@@ -1,4 +1,4 @@
-mutation($token: String!, $payload: ResetPasswordPayload!) {
+mutation resetPassword ($token: String!, $payload: ResetPasswordPayload!) {
   User {
     resetPassword(token: $token, payload: $payload)
   }

--- a/front/src/api/graphql/mutation/user/UpdateMe.graphql
+++ b/front/src/api/graphql/mutation/user/UpdateMe.graphql
@@ -1,6 +1,6 @@
 #import "@graphql/fragments/user/_User.graphql"
 
-mutation($payload: MyProfilePayload!) {
+mutation updateMe ($payload: MyProfilePayload!) {
   User {
     updateMyProfile(payload: $payload) {
       ..._User

--- a/front/src/api/graphql/mutation/user/UpdateUser.graphql
+++ b/front/src/api/graphql/mutation/user/UpdateUser.graphql
@@ -1,4 +1,4 @@
-mutation($uid: ULID!, $payload: UserPayload!) {
+mutation updateUser ($uid: ULID!, $payload: UserPayload!) {
   User {
     update(uid: $uid, payload: $payload) {
       uid

--- a/front/src/api/graphql/query/apiary/FindApiary.graphql
+++ b/front/src/api/graphql/query/apiary/FindApiary.graphql
@@ -1,4 +1,4 @@
-query($uid: ULID!) {
+query findApiary ($uid: ULID!) {
   Apiary {
     find(uid: $uid) {
       uid

--- a/front/src/api/graphql/query/beehive/FindBeehive.graphql
+++ b/front/src/api/graphql/query/beehive/FindBeehive.graphql
@@ -1,4 +1,4 @@
-query($uid: ULID!) {
+query findBeehive ($uid: ULID!) {
   Beehive {
     find(uid: $uid) {
       uid

--- a/front/src/api/graphql/query/beehive/ListBeeType.graphql
+++ b/front/src/api/graphql/query/beehive/ListBeeType.graphql
@@ -1,5 +1,5 @@
-query {
+query ListBeeType {
   Beehive {
-    listBeeType 
+    listBeeType
   }
 }

--- a/front/src/api/graphql/query/user/FindUser.graphql
+++ b/front/src/api/graphql/query/user/FindUser.graphql
@@ -1,6 +1,6 @@
 #import "@graphql/fragments/user/_User.graphql"
 
-query($uid: ULID!) {
+query findUser ($uid: ULID!) {
   User {
     find(uid: $uid) {
       isAdmin

--- a/front/src/api/graphql/store/beehives.ts
+++ b/front/src/api/graphql/store/beehives.ts
@@ -1,29 +1,34 @@
 import { ApolloCache } from '@apollo/client';
 import ListBeehivesQuery from '@graphql/query/beehive/ListBeehives.graphql';
 
-interface ApiaryRef {
+interface BeehiveRef {
   uid: string
+  apiary: {
+    uid: string
+  }
 }
 
 interface Store {
   Beehive: {
-    listMyBeehives: ApiaryRef[]
+    listBeehivesFromApiary: BeehiveRef[]
   }
 }
 
 /**
- * Update Apollo store on new service created.
+ * Update Apollo store on new beehive created.
  * Should make the new item visible on the listing.
  *
  * @see https://www.apollographql.com/docs/react/caching/cache-interaction/#using-graphql-queries
  */
 export function onCreateBeehive(
   store: ApolloCache<unknown>,
-  beehive: ApiaryRef,
+  beehive: BeehiveRef,
 ) {
   const query = ListBeehivesQuery;
+  const variables = { apiaryUid: beehive.apiary.uid };
+
   // Attempt to read the data from the cache:
-  const previousData = store.readQuery<Store>({ query });
+  const previousData = store.readQuery<Store>({ query, variables });
 
   if (!previousData) {
     // If no data was fetched yet, we don't need to do anything
@@ -34,11 +39,11 @@ export function onCreateBeehive(
     ...previousData,
     Beehive: {
       ...previousData.Beehive,
-      // Append the newly created service to the list:
-      list: [...previousData.Beehive.listMyBeehives, beehive],
+      // Append the newly created beehive to the list:
+      listBeehivesFromApiary: [...previousData.Beehive.listBeehivesFromApiary, beehive],
     },
   };
 
   // Write the data back to the cache:
-  store.writeQuery({ query, data });
+  store.writeQuery({ query, data, variables });
 }

--- a/front/src/components/BeeHive/BeehiveForm.tsx
+++ b/front/src/components/BeeHive/BeehiveForm.tsx
@@ -88,7 +88,7 @@ export default function BeehiveForm({
     <h2>
       {isUpdate
         ? trans('pages.beehiveForm.update.documentTitle')
-        : trans('pages.apiaryForm.create.documentTitle')}
+        : trans('pages.beehiveForm.create.documentTitle')}
     </h2>
     <FormRootErrors errors={errors?.name} />
     <Stack>

--- a/front/src/pages/Admin/User/ListUsers/ListUsers.tsx
+++ b/front/src/pages/Admin/User/ListUsers/ListUsers.tsx
@@ -61,7 +61,7 @@ const Page = declareAdminRoute(function ListUsers() {
     update(cache, { data }) {
       onDeleteUser(cache, data!.User.delete);
     },
-  });
+  });//todo: do this only on hard delete
 
   const mappedErrors = useMemo(() => {
     const error = mutationState.error;

--- a/front/src/pages/Beehive/Forms/BeehiveUpdate.tsx
+++ b/front/src/pages/Beehive/Forms/BeehiveUpdate.tsx
@@ -3,7 +3,7 @@ import { useDocumentTitle } from '@mantine/hooks';
 import FindBeehiveQuery from '@graphql/query/beehive/FindBeehive.graphql';
 import UpdateBeehiveMutation from '@graphql/mutation/beehive/UpdateBeehive.graphql';
 import { trans } from '@app/translations';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { useNotFoundHandler } from '@app/components/ErrorBoundary.tsx';
 import { useQuery } from '@apollo/client';
 import { useMemo } from 'react';
@@ -33,12 +33,16 @@ interface FindBeehiveQueryResponse {
   }
 }
 
+interface RedirectFromCreationState {
+  beehiveCreated: boolean
+}
 
 const BeehiveUpdatePage = declareRoute(function BeehiveUpdate() {
   useDocumentTitle(trans('pages.beehiveForm.update.documentTitle'));
 
   const { uid } = useParams();
   const notFoundHandler = useNotFoundHandler();
+  const { beehiveCreated } = (useLocation().state ?? {}) as RedirectFromCreationState;
 
   const query = useQuery<FindBeehiveQueryResponse>(FindBeehiveQuery, {
     variables: { uid },
@@ -47,7 +51,6 @@ const BeehiveUpdatePage = declareRoute(function BeehiveUpdate() {
       onNotFound: notFoundHandler,
     },
   });
-  const beehive = query.data?.Beehive.find;
 
   const [mutate, mutationState] = useMutation<MutationResponse>(UpdateBeehiveMutation);
 
@@ -77,14 +80,14 @@ const BeehiveUpdatePage = declareRoute(function BeehiveUpdate() {
     return <p>{trans('common.loading')}</p>;
   }
 
-
+  const beehive = query.data?.Beehive.find;
 
   return <Container px="md">
+    {beehiveCreated && !mutationState.called && <Alert title="Success" variant="success">
+      Ruche créée avec succès.
+    </Alert>}
     {mutationState.called && mutationState.data?.Beehive && <Alert title="Success" variant="success">
       Ruche modifiée avec succès.
-    </Alert>}
-    {mutationState.error && <Alert title="Fail" variant="warning">
-      Erreur lors de la modification Resaisissez les données
     </Alert>}
 
     <BeehiveForm onSubmit={submit} errors={mappedErrors} initialData={beehive} />


### PR DESCRIPTION
Fixes : 

- [x] Redirection après la création d'une ruche à sa page d'update
- [x] Messages de confirmation et d'erreurs pas à leur place
- [x] Le cache de la liste des ruches pas à jour
- [x] Les bonnes pratiques GraphQL en matière de nommage